### PR TITLE
Integrate Wasm allocator in the example flight server.

### DIFF
--- a/flight-server/build.gradle
+++ b/flight-server/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation 'org.apache.arrow:arrow-vector:4.0.0'
     implementation 'org.apache.arrow:arrow-tools:4.0.0'
     implementation 'org.apache.arrow:flight-core:4.0.0'
+    implementation project(':java-wasm-allocator')
 }
 
 task fatJar(type: Jar) {

--- a/flight-server/relay.sh
+++ b/flight-server/relay.sh
@@ -6,4 +6,4 @@ if [ $# -ne 1 ]; then
 fi
 
 
-java --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED -Dlogback.configurationFile=file:../resources/logging.xml -cp "./build/libs/flight-server-all.jar" org.m4d.adp.flight_server.ExampleFlightServer relay $1 0.0.0.0 12232 localhost 12233
+java --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED -Dlogback.configurationFile=file:../resources/logging.xml -cp "./build/libs/flight-server-all.jar" org.m4d.adp.flight_server.ExampleFlightServer -s relay -t $1 -h 0.0.0.0 -p 12232 -rh localhost -rp 12233

--- a/flight-server/server.sh
+++ b/flight-server/server.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED -Dlogback.configurationFile=file:../resources/logging.xml -cp "./build/libs/flight-server-all.jar" org.m4d.adp.flight_server.ExampleFlightServer example localhost 12233
+java --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED -Dlogback.configurationFile=file:../resources/logging.xml -cp "./build/libs/flight-server-all.jar" org.m4d.adp.flight_server.ExampleFlightServer -s example -h localhost --port 12233

--- a/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
+++ b/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
@@ -108,22 +108,22 @@ public class ExampleFlightServer implements AutoCloseable {
         host = line.getOptionValue("host", "0.0.0.0");
         port = Integer.valueOf(line.getOptionValue("port", "12232"));
       
-        if (line.hasOption("server_type")) {
-            String[] argVal = line.getOptionValues("server_type");
-            if (!argVal[0].equals("example") && !argVal[0].equals("relay")) {
-                System.out.println("Only acceptable arguments are 'direct' or 'relay'. got " + argVal[0]);
-                System.exit(-1);
-            }
-            else if (argVal[0].equals("relay")) {
-                relay = true;
-                if (argVal.length == 2) {
-                    transform = Boolean.valueOf(argVal[1]);
-                }
-            }
-        }else {
-            System.out.println("Need a 'prod' argument: either 'example' or 'relay'");
-            System.exit(-1);
-        }
+        // if (line.hasOption("server_type")) {
+        //     String[] argVal = line.getOptionValues("server_type");
+        //     if (!argVal[0].equals("example") && !argVal[0].equals("relay")) {
+        //         System.out.println("Only acceptable arguments are 'direct' or 'relay'. got " + argVal[0]);
+        //         System.exit(-1);
+        //     } 
+        //     else if (argVal[0].equals("relay")) {
+        //         relay = true;
+        //         if (argVal.length == 2) {
+        //             transform = Boolean.valueOf(argVal[1]);
+        //         }
+        //     }
+        // } else {
+        //     System.out.println("Need a 'server-type' argument: either 'example' or 'relay'");
+        //     System.exit(-1);
+        // }
         
         final Location location;
         final NoOpFlightProducer producer;

--- a/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
+++ b/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
@@ -12,6 +12,7 @@ import org.m4d.adp.allocator.WasmAllocationFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
 /**
@@ -69,6 +70,7 @@ public class ExampleFlightServer implements AutoCloseable {
         BufferAllocator a;
         CommandLineParser parser = new DefaultParser();
         Options options = new Options();
+
         options.addOption("a", "alloc", true, "Allocation type");
         options.addOption("s", "server_type", true, "Server type");
         options.addOption("t", "transformation", false, "relay transformation(true/false)");
@@ -76,6 +78,7 @@ public class ExampleFlightServer implements AutoCloseable {
         options.addOption("p", "port", true, "Port");
         options.addOption("rh", "remote_host", true, "Remote host");
         options.addOption("rp", "remote_port", true, "Remote port");
+
         CommandLine line = parser.parse( options, args );
         String allocator_type = line.getOptionValue("alloc", "Root");
         if(allocator_type.equals("wasm")) {

--- a/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
+++ b/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
@@ -6,6 +6,13 @@ import org.apache.arrow.flight.*;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.AutoCloseables;
+import org.apache.arrow.memory.AllocationManager;
+import org.m4d.adp.allocator.WasmAllocationManager;
+import org.m4d.adp.allocator.WasmAllocationFactory;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
 
 /**
  * An Example Flight Server that provides access to the InMemoryStore. Used for integration testing.
@@ -33,42 +40,91 @@ public class ExampleFlightServer implements AutoCloseable {
         flightServer.awaitTermination();
     }
 
+    private static BufferAllocator createWasmAllocator(AllocationManager.Factory factory) {
+        return new RootAllocator(RootAllocator.configBuilder().allocationManagerFactory(factory)
+            .build());
+    }
+
     /**
      *  Main method starts the server listening to localhost:12233.
      */
     public static void main(String[] args) throws Exception {
-        if ((args.length != 3) && (args.length != 6)) {
-            System.out.println("Arguments are either:");
-            System.out.println("\texample host port");
-            System.out.println("\trelay transformation(true/false) host port remote_host remote_port");
-            System.exit(-1);
-        }
+        // if ((args.length != 3) && (args.length != 6)) {
+        //     System.out.println("Arguments are either:");
+        //     System.out.println("\texample host port");
+        //     System.out.println("\trelay transformation(true/false) host port remote_host remote_port");
+        //     System.exit(-1);
+        // }
 
+        boolean relay = false;
+        boolean transform = false;
         String host;
         int port;
         String remote_host = null;
         int remote_port = 0;
 
-        if (!args[0].equals("example") && !args[0].equals("relay")) {
-            System.out.println("Only acceptable arguments are 'direct' or 'relay'. got " + args[0]);
+        // if (!args[0].equals("example") && !args[0].equals("relay")) {
+        //     System.out.println("Only acceptable arguments are 'direct' or 'relay'. got " + args[0]);
+        //     System.exit(-1);
+        BufferAllocator a;
+        CommandLineParser parser = new DefaultParser();
+        Options options = new Options();
+        options.addOption("a", "alloc", true, "Allocation type");
+        options.addOption("s", "server_type", true, "Server type");
+        options.addOption("t", "transformation", false, "relay transformation(true/false)");
+        options.addOption("h", "host", true, "Host");
+        options.addOption("p", "port", true, "Port");
+        options.addOption("rh", "remote_host", true, "Remote host");
+        options.addOption("rp", "remote_port", true, "Remote port");
+        CommandLine line = parser.parse( options, args );
+        String allocator_type = line.getOptionValue("alloc", "Root");
+        if(allocator_type.equals("wasm")) {
+            WasmAllocationFactory wasmAllocationFactory = new WasmAllocationFactory();
+            a = createWasmAllocator(wasmAllocationFactory);
+        } else {
+            a = new RootAllocator(Long.MAX_VALUE);
+        }
+        
+        // if(line.hasOption("alloc")){
+        //     String[] argVal = line.getOptionValues("alloc");
+        //     if(argVal[0].equals("wasm")) {
+        //         WasmAllocationFactory wasmAllocationFactory = new WasmAllocationFactory();
+        //         a = createWasmAllocator(wasmAllocationFactory);
+        //     }else {
+        //         a = new RootAllocator(Long.MAX_VALUE);
+        //     }
+        // }else{
+        //     a = new RootAllocator(Long.MAX_VALUE);
+        // }
+        
+
+        String server_type_arg = line.getOptionValue("server_type", "example");
+        if (server_type_arg.equals("relay")) {
+            relay = true;
+            transform = line.hasOption("transformation");
+            remote_host = line.getOptionValue("remote_host", "localhost");
+            remote_port = Integer.valueOf(line.getOptionValue("port", "12233"));
+        }
+        host = line.getOptionValue("host", "0.0.0.0");
+        port = Integer.valueOf(line.getOptionValue("port", "12232"));
+      
+        if (line.hasOption("server_type")) {
+            String[] argVal = line.getOptionValues("server_type");
+            if (!argVal[0].equals("example") && !argVal[0].equals("relay")) {
+                System.out.println("Only acceptable arguments are 'direct' or 'relay'. got " + argVal[0]);
+                System.exit(-1);
+            }
+            else if (argVal[0].equals("relay")) {
+                relay = true;
+                if (argVal.length == 2) {
+                    transform = Boolean.valueOf(argVal[1]);
+                }
+            }
+        }else {
+            System.out.println("Need a 'prod' argument: either 'example' or 'relay'");
             System.exit(-1);
         }
-
-        boolean relay = false;
-        boolean transform = false;
-        if (args[0].equals("relay")) {
-            relay = true;
-            transform = Boolean.valueOf(args[1]);
-            host = args[2];
-            port = Integer.valueOf(args[3]);
-            remote_host = args[4];
-            remote_port = Integer.valueOf(args[5]);
-        } else {
-            host = args[1];
-            port = Integer.valueOf(args[2]);
-        }
-
-        final BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
+        
         final Location location;
         final NoOpFlightProducer producer;
         if (relay) {

--- a/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
+++ b/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
@@ -12,6 +12,7 @@ import org.m4d.adp.allocator.WasmAllocationFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
 /**
@@ -53,7 +54,9 @@ public class ExampleFlightServer implements AutoCloseable {
         CommandLineParser parser = new DefaultParser();
         Options options = new Options();
         options.addOption("alloc", true, "Allocation type");
-        options.addOption("server-type", true, "Server type");
+        Option type = new Option("servertype", "Server type");
+        type.setArgs(2);
+        options.addOption(type);
         CommandLine line = parser.parse( options, args );
         if(line.hasOption("alloc")){
             String[] argVal = line.getOptionValues("alloc");
@@ -69,8 +72,8 @@ public class ExampleFlightServer implements AutoCloseable {
         
         boolean relay = false;
         boolean transform = false;
-        if (line.hasOption("server-type")) {
-            String[] argVal = line.getOptionValues("server-type");
+        if (line.hasOption("servertype")) {
+            String[] argVal = line.getOptionValues("servertype");
             if (!argVal[0].equals("example") && !argVal[0].equals("relay")) {
                 System.out.println("Only acceptable arguments are 'direct' or 'relay'. got " + argVal[0]);
                 System.exit(-1);
@@ -82,7 +85,7 @@ public class ExampleFlightServer implements AutoCloseable {
                 }
             }
         } else {
-            System.out.println("Need a 'server-type' argument: either 'example' or 'relay'");
+            System.out.println("Need a 'servertype' argument: either 'example' or 'relay'");
             System.exit(-1);
         }
         

--- a/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
+++ b/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
@@ -53,36 +53,36 @@ public class ExampleFlightServer implements AutoCloseable {
         CommandLineParser parser = new DefaultParser();
         Options options = new Options();
         options.addOption("alloc", true, "Allocation type");
-        options.addOption("prod", true, "Producer type");
+        options.addOption("server-type", true, "Server type");
         CommandLine line = parser.parse( options, args );
         if(line.hasOption("alloc")){
             String[] argVal = line.getOptionValues("alloc");
             if(argVal[0].equals("wasm")) {
                 WasmAllocationFactory wasmAllocationFactory = new WasmAllocationFactory();
                 a = createWasmAllocator(wasmAllocationFactory);
-            }else {
+            } else {
                 a = new RootAllocator(Long.MAX_VALUE);
             }
-        }else{
+        } else {
             a = new RootAllocator(Long.MAX_VALUE);
         }
         
         boolean relay = false;
         boolean transform = false;
-        if (line.hasOption("prod")) {
-            String[] argVal = line.getOptionValues("prod");
+        if (line.hasOption("server-type")) {
+            String[] argVal = line.getOptionValues("server-type");
             if (!argVal[0].equals("example") && !argVal[0].equals("relay")) {
                 System.out.println("Only acceptable arguments are 'direct' or 'relay'. got " + argVal[0]);
                 System.exit(-1);
-            }
+            } 
             else if (argVal[0].equals("relay")) {
                 relay = true;
                 if (argVal.length == 2) {
                     transform = Boolean.valueOf(argVal[1]);
                 }
             }
-        }else {
-            System.out.println("Need a 'prod' argument: either 'example' or 'relay'");
+        } else {
+            System.out.println("Need a 'server-type' argument: either 'example' or 'relay'");
             System.exit(-1);
         }
         

--- a/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
+++ b/flight-server/src/main/java/org/m4d/adp/flight_server/ExampleFlightServer.java
@@ -50,30 +50,19 @@ public class ExampleFlightServer implements AutoCloseable {
      *  Main method starts the server listening to localhost:12233.
      */
     public static void main(String[] args) throws Exception {
-        // if ((args.length != 3) && (args.length != 6)) {
-        //     System.out.println("Arguments are either:");
-        //     System.out.println("\texample host port");
-        //     System.out.println("\trelay transformation(true/false) host port remote_host remote_port");
-        //     System.exit(-1);
-        // }
-
         boolean relay = false;
         boolean transform = false;
         String host;
         int port;
         String remote_host = null;
         int remote_port = 0;
-
-        // if (!args[0].equals("example") && !args[0].equals("relay")) {
-        //     System.out.println("Only acceptable arguments are 'direct' or 'relay'. got " + args[0]);
-        //     System.exit(-1);
         BufferAllocator a;
         CommandLineParser parser = new DefaultParser();
         Options options = new Options();
 
         options.addOption("a", "alloc", true, "Allocation type");
         options.addOption("s", "server_type", true, "Server type");
-        options.addOption("t", "transformation", false, "relay transformation(true/false)");
+        options.addOption("t", "transformation", true, "relay transformation(true/false)");
         options.addOption("h", "host", true, "Host");
         options.addOption("p", "port", true, "Port");
         options.addOption("rh", "remote_host", true, "Remote host");
@@ -87,46 +76,15 @@ public class ExampleFlightServer implements AutoCloseable {
         } else {
             a = new RootAllocator(Long.MAX_VALUE);
         }
-        
-        // if(line.hasOption("alloc")){
-        //     String[] argVal = line.getOptionValues("alloc");
-        //     if(argVal[0].equals("wasm")) {
-        //         WasmAllocationFactory wasmAllocationFactory = new WasmAllocationFactory();
-        //         a = createWasmAllocator(wasmAllocationFactory);
-        //     }else {
-        //         a = new RootAllocator(Long.MAX_VALUE);
-        //     }
-        // }else{
-        //     a = new RootAllocator(Long.MAX_VALUE);
-        // }
-        
-
         String server_type_arg = line.getOptionValue("server_type", "example");
         if (server_type_arg.equals("relay")) {
             relay = true;
-            transform = line.hasOption("transformation");
+            transform = Boolean.valueOf(line.getOptionValue("transformation", "false"));
             remote_host = line.getOptionValue("remote_host", "localhost");
-            remote_port = Integer.valueOf(line.getOptionValue("port", "12233"));
+            remote_port = Integer.valueOf(line.getOptionValue("remote_port", "12233"));
         }
         host = line.getOptionValue("host", "0.0.0.0");
         port = Integer.valueOf(line.getOptionValue("port", "12232"));
-      
-        // if (line.hasOption("server_type")) {
-        //     String[] argVal = line.getOptionValues("server_type");
-        //     if (!argVal[0].equals("example") && !argVal[0].equals("relay")) {
-        //         System.out.println("Only acceptable arguments are 'direct' or 'relay'. got " + argVal[0]);
-        //         System.exit(-1);
-        //     } 
-        //     else if (argVal[0].equals("relay")) {
-        //         relay = true;
-        //         if (argVal.length == 2) {
-        //             transform = Boolean.valueOf(argVal[1]);
-        //         }
-        //     }
-        // } else {
-        //     System.out.println("Need a 'server-type' argument: either 'example' or 'relay'");
-        //     System.exit(-1);
-        // }
         
         final Location location;
         final NoOpFlightProducer producer;


### PR DESCRIPTION
Adding an option to use Wasm allocator to the example flight server. To use it we should give an argument `-alloc wasm`.
Also changing the command line arguments parsing. To choose a producer we should use `-prod <producer name>`.

Closes #17 

Signed-off-by: Mohammad-nassar10 <mohammad.nassar@ibm.com>