### PR TITLE
Build `java-wasm-interface` before `flight-server`.

### DIFF
--- a/flight-server/build.gradle
+++ b/flight-server/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 }
 
 task fatJar(type: Jar) {
+  dependsOn ':java-wasm-interface:build'
   manifest.from jar.manifest
   classifier = 'all'
   from {

--- a/wasm_interface/.gitignore
+++ b/wasm_interface/.gitignore
@@ -2,6 +2,7 @@
 # will have compiled files and executables
 debug/
 target/
+artifacts/
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html


### PR DESCRIPTION
Adding a dependency in `fatJar` task in `flight-server` project in order to fix a problem with `./gradlew build` which builds `flight-server` project before `java-wasm-interface` project (because it executes the build lexicographically).

Signed-off-by: Mohammad Nassar <mohammad.nassar@ibm.com>